### PR TITLE
Persist gameweek data for future model training

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ FPL_DATA_INFERENCE_ENABLED=false
 
 ## Docker
 
-The image intentionally excludes generated data and model artifacts. Mount both
-directories read-only at their configured runtime paths:
+The image intentionally excludes generated data and model artifacts. Mount the
+data directory read-write and the model directory read-only at their configured
+runtime paths:
 
 ```bash
 docker build --platform linux/amd64 -t openfpl-scout-ai .
@@ -72,7 +73,7 @@ docker run --rm \
   --name openfpl-scout-ai \
   -p 8000:8000 \
   -e VALID_API_KEYS=local-development-token \
-  --mount type=bind,src="${PWD}/data",dst=/app/data,readonly \
+  --mount type=bind,src="${PWD}/data",dst=/app/data \
   --mount type=bind,src="${PWD}/models",dst=/app/models,readonly \
   openfpl-scout-ai
 ```
@@ -80,7 +81,9 @@ docker run --rm \
 The container defaults to port `8000` and honors the `PORT` environment
 variable supplied by Cloud Run. A Cloud Run revision must expose equivalent
 volumes at `/app/data` and `/app/models`; local Docker bind mounts are not
-transferred with the image.
+transferred with the image. The model volume can be read-only, but the data
+volume and its bucket permissions must allow the service to create and replace
+objects.
 
 For a low-traffic Cloud Run service, start with request-based billing, 1 vCPU,
 512 MiB, concurrency 4, scale-to-zero, and a three-instance cost cap:
@@ -132,6 +135,39 @@ Runtime data flows from official FPL through the shared feature pipeline, model
 ensemble, and squad selector. The optional enrichment layer accepts only the
 configured season, fills missing values only, rejects stale or poorly matched
 data, and falls back to official-only inference on failure.
+
+Every successful scout inference also maintains a durable, season-scoped
+archive under `data/archive/<season>/`. The archive is fail-open, so a temporary
+storage failure is reported in `/api/health` without taking predictions down.
+Set `OPENFPL_DATA_ARCHIVE_ENABLED=false` to disable it or
+`OPENFPL_DATA_ROOT=/data` when the Cloud Run volume is mounted at `/data`
+instead of `/app/data`. This single override relocates both the archive and the
+durable enrichment source. `OPENFPL_DATA_ARCHIVE_ROOT` can override only the
+archive location when needed.
+
+```text
+data/
+├── external/                         # durable complete FPL Data source + metadata
+└── archive/2026-2027/
+    ├── official/
+    │   ├── snapshots/gw_03/          # raw bootstrap and fixture payloads
+    │   ├── live/gw_02.json           # complete event-live player payload
+    │   ├── history/before_gw_03.csv  # cumulative official history
+    │   └── player-stats/gw_02.csv    # one training table per played GW
+    ├── enriched/
+    │   ├── history/before_gw_03.csv
+    │   └── player-stats/gw_02.csv
+    ├── predictions/gw_03.csv
+    ├── squads/gw_03.json
+    └── metadata/gw_03.json
+```
+
+Official history CSVs retain the normalized model fields and every raw
+gameweek-history field with an `official_` prefix. Completed live files are
+immutable; the current gameweek, upcoming predictions, and snapshots are
+refreshed as new requests arrive. Invoke `/api/scout` at least once after each
+gameweek is finalized (for example with Cloud Scheduler) to guarantee a
+complete season even when the service otherwise receives no traffic.
 
 Archive active-season official history for future training:
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -77,11 +77,18 @@ fpl_data_inference:
   start_gameweek: 2
   season: "2026_27"
   local_path: "data/external/fpl-data-stats-2027.csv"
-  runtime_cache_path: "/tmp/openfpl/fpl-data-stats-2027.csv"
+  runtime_cache_path: "data/external/fpl-data-stats-2027.csv"
   refresh_ttl_seconds: 21600
   minimum_match_ratio: 0.8
   timeout_seconds: 60
   permission_status: "pending"
+
+# Durable artifacts for future training. In Cloud Run, the data root must be a
+# writable bucket volume. Set OPENFPL_DATA_ROOT=/data for a /data mount.
+data_archive:
+  enabled: true
+  root_path: "data/archive"
+  season: "auto"
 
 # Model Information
 models:

--- a/main.py
+++ b/main.py
@@ -237,6 +237,7 @@ async def check_health():
             "permission_status": scout.fpl_data_permission_status,
             "last_result": scout.last_data_enrichment,
         },
+        "data_archive": scout.data_archive.status(),
         "models": len(scout.model_artifacts),
     }
 
@@ -781,6 +782,7 @@ async def _generate_scout_response(
     try:
         predictions = await run_in_threadpool(scout.get_official_predictions, gameweek)
         team = await run_in_threadpool(scout.select_optimal_team, predictions)
+        await run_in_threadpool(scout.data_archive.capture_squad, predictions, team)
         prediction_gameweek = int(predictions.attrs["gameweek"])
         if public:
             logger.info(

--- a/src/data_archive.py
+++ b/src/data_archive.py
@@ -1,0 +1,424 @@
+"""Durable, fail-open archives for future OpenFPL model training."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import tempfile
+from datetime import date, datetime, timezone
+from pathlib import Path
+from threading import RLock
+from typing import Any, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _environment_bool(name: str) -> Optional[bool]:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    normalized = value.strip().casefold()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be true or false")
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert pandas/numpy values into strict JSON-compatible values."""
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, np.generic):
+        return _json_safe(value.item())
+    if isinstance(value, (pd.Timestamp, datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    if value is pd.NA:
+        return None
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    return value
+
+
+class DataArchive:
+    """Write reproducible gameweek artifacts to a mounted data directory.
+
+    Writes are deliberately fail-open: prediction requests continue if an
+    archive bucket is temporarily unavailable. Stable gameweek paths are
+    replaced with the freshest snapshot, while finalized live event files are
+    treated as immutable.
+    """
+
+    SCHEMA_VERSION = 1
+
+    def __init__(
+        self,
+        root_path: Path,
+        *,
+        enabled: bool = True,
+        configured_season: str = "auto",
+    ) -> None:
+        self.root_path = Path(root_path)
+        self.enabled = bool(enabled)
+        self.configured_season = configured_season.strip() or "auto"
+        self._lock = RLock()
+        self._digests: dict[Path, str] = {}
+        self.last_result: dict[str, Any] = {"status": "not-attempted"}
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> "DataArchive":
+        archive_config = config.get("data_archive", {})
+        configured_enabled = bool(archive_config.get("enabled", False))
+        environment_enabled = _environment_bool("OPENFPL_DATA_ARCHIVE_ENABLED")
+        enabled = (
+            configured_enabled
+            if environment_enabled is None
+            else environment_enabled
+        )
+        root = os.environ.get("OPENFPL_DATA_ARCHIVE_ROOT")
+        if root is None:
+            data_root = os.environ.get("OPENFPL_DATA_ROOT")
+            root = (
+                str(Path(data_root) / "archive")
+                if data_root
+                else str(archive_config.get("root_path", "data/archive"))
+            )
+        return cls(
+            Path(root),
+            enabled=enabled,
+            configured_season=str(archive_config.get("season", "auto")),
+        )
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "root_path": str(self.root_path),
+            "last_result": dict(self.last_result),
+        }
+
+    def capture_inference(
+        self,
+        *,
+        official_client: Any,
+        prediction_gameweek: int,
+        official_history: pd.DataFrame,
+        enriched_history: pd.DataFrame,
+        predictions: pd.DataFrame,
+        source: str,
+        enrichment: Mapping[str, Any],
+        model_versions: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Persist official inputs, enriched inputs, and model predictions."""
+        if not self.enabled:
+            return {"status": "disabled"}
+
+        try:
+            result = self._capture_inference(
+                official_client=official_client,
+                prediction_gameweek=int(prediction_gameweek),
+                official_history=official_history,
+                enriched_history=enriched_history,
+                predictions=predictions,
+                source=source,
+                enrichment=enrichment,
+                model_versions=model_versions,
+            )
+        except Exception as error:  # Archive availability must not break inference.
+            logger.exception("Could not persist the gameweek data archive")
+            result = {"status": "failed", "error": str(error)}
+        self.last_result = result
+        return result
+
+    def _capture_inference(
+        self,
+        *,
+        official_client: Any,
+        prediction_gameweek: int,
+        official_history: pd.DataFrame,
+        enriched_history: pd.DataFrame,
+        predictions: pd.DataFrame,
+        source: str,
+        enrichment: Mapping[str, Any],
+        model_versions: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        bootstrap = official_client.bootstrap()
+        fixtures = official_client.fixtures()
+        season = self._season_name(bootstrap)
+        season_root = self.root_path / season
+        gameweek_name = f"gw_{prediction_gameweek:02d}"
+        captured_at = datetime.now(timezone.utc).isoformat()
+        finished_gameweeks = [
+            int(event["id"])
+            for event in bootstrap.get("events", [])
+            if event.get("finished")
+        ]
+        history_cutoff_gameweek = max(
+            prediction_gameweek,
+            max(finished_gameweeks, default=0) + 1,
+        )
+
+        # Archive removed/unavailable players too. Existing official HTTP cache
+        # makes this inexpensive for the selectable players already fetched.
+        # The cutoff reaches 39 after GW38 so the final event is not omitted.
+        try:
+            complete_official_history = official_client.player_history(
+                history_cutoff_gameweek, selectable_only=False
+            )
+        except TypeError:
+            complete_official_history = official_history
+
+        written: list[str] = []
+        snapshot_root = season_root / "official" / "snapshots" / gameweek_name
+        self._record_write(
+            written,
+            season_root,
+            snapshot_root / "bootstrap.json",
+            self._json_bytes(bootstrap),
+        )
+        self._record_write(
+            written,
+            season_root,
+            snapshot_root / "fixtures.json",
+            self._json_bytes(fixtures),
+        )
+        self._record_frame(
+            written,
+            season_root,
+            season_root
+            / "official"
+            / "history"
+            / f"before_gw_{history_cutoff_gameweek:02d}.csv",
+            complete_official_history,
+        )
+        self._record_gameweek_frames(
+            written,
+            season_root,
+            season_root / "official" / "player-stats",
+            complete_official_history,
+        )
+        self._record_frame(
+            written,
+            season_root,
+            season_root / "enriched" / "history" / f"before_{gameweek_name}.csv",
+            enriched_history,
+        )
+        self._record_gameweek_frames(
+            written,
+            season_root,
+            season_root / "enriched" / "player-stats",
+            enriched_history,
+        )
+        self._record_frame(
+            written,
+            season_root,
+            season_root / "predictions" / f"{gameweek_name}.csv",
+            predictions,
+        )
+
+        live_gameweeks = self._archive_live_gameweeks(
+            official_client, bootstrap, season_root, written
+        )
+        metadata = {
+            "archive_schema_version": self.SCHEMA_VERSION,
+            "captured_at_utc": captured_at,
+            "season": season,
+            "prediction_gameweek": prediction_gameweek,
+            "official_history_before_gameweek": history_cutoff_gameweek,
+            "source": source,
+            "rows": {
+                "official_history": len(complete_official_history),
+                "enriched_history": len(enriched_history),
+                "predictions": len(predictions),
+            },
+            "live_gameweeks": live_gameweeks,
+            "enrichment": enrichment,
+            "inference": predictions.attrs.get("inference", {}),
+            "models": model_versions,
+        }
+        self._record_write(
+            written,
+            season_root,
+            season_root / "metadata" / f"{gameweek_name}.json",
+            self._json_bytes(metadata),
+        )
+        result = {
+            "status": "saved",
+            "season": season,
+            "prediction_gameweek": prediction_gameweek,
+            "files_updated": written,
+        }
+        logger.info(
+            "Archived prediction GW%d under %s (%d files updated)",
+            prediction_gameweek,
+            season_root,
+            len(written),
+        )
+        return result
+
+    def capture_squad(
+        self,
+        predictions: pd.DataFrame,
+        squad: pd.DataFrame,
+    ) -> dict[str, Any]:
+        """Persist the selected squad after a successful optimization."""
+        if not self.enabled:
+            return {"status": "disabled"}
+        try:
+            prediction_gameweek = int(predictions.attrs["gameweek"])
+            season = str(
+                self.last_result.get("season") or self.configured_season
+            )
+            if season == "auto":
+                raise ValueError("Season is unavailable before inference is archived")
+            target = (
+                self.root_path
+                / season
+                / "squads"
+                / f"gw_{prediction_gameweek:02d}.json"
+            )
+            payload = {
+                "archive_schema_version": self.SCHEMA_VERSION,
+                "captured_at_utc": datetime.now(timezone.utc).isoformat(),
+                "season": season,
+                "prediction_gameweek": prediction_gameweek,
+                "strategy": predictions.attrs.get("inference", {}).get("strategy"),
+                "source": predictions.attrs.get("source", "official-fpl"),
+                "players": squad.to_dict(orient="records"),
+            }
+            updated = self._write_bytes(target, self._json_bytes(payload))
+            return {
+                "status": "saved",
+                "path": str(target),
+                "updated": updated,
+            }
+        except Exception as error:  # Archive availability must not break the API.
+            logger.exception("Could not persist the selected squad")
+            return {"status": "failed", "error": str(error)}
+
+    def _archive_live_gameweeks(
+        self,
+        official_client: Any,
+        bootstrap: Mapping[str, Any],
+        season_root: Path,
+        written: list[str],
+    ) -> list[int]:
+        archived: list[int] = []
+        for event in bootstrap.get("events", []):
+            gameweek = int(event["id"])
+            finished = bool(event.get("finished"))
+            current = bool(event.get("is_current"))
+            if not finished and not current:
+                continue
+            target = season_root / "official" / "live" / f"gw_{gameweek:02d}.json"
+            if finished and target.is_file():
+                archived.append(gameweek)
+                continue
+            try:
+                payload = official_client.event_live(gameweek)
+            except AttributeError:
+                payload = official_client.mapped_event_live(gameweek)
+            self._record_write(
+                written, season_root, target, self._json_bytes(payload)
+            )
+            archived.append(gameweek)
+        return archived
+
+    def _record_gameweek_frames(
+        self,
+        written: list[str],
+        season_root: Path,
+        directory: Path,
+        frame: pd.DataFrame,
+    ) -> None:
+        if "gameweek" not in frame.columns or frame.empty:
+            return
+        gameweeks = pd.to_numeric(frame["gameweek"], errors="coerce")
+        for gameweek in sorted(int(value) for value in gameweeks.dropna().unique()):
+            if gameweek < 1:
+                continue
+            rows = frame.loc[gameweeks == gameweek].copy()
+            self._record_frame(
+                written,
+                season_root,
+                directory / f"gw_{gameweek:02d}.csv",
+                rows,
+            )
+
+    def _record_frame(
+        self,
+        written: list[str],
+        season_root: Path,
+        path: Path,
+        frame: pd.DataFrame,
+    ) -> None:
+        content = frame.to_csv(index=False).encode("utf-8")
+        self._record_write(written, season_root, path, content)
+
+    def _record_write(
+        self,
+        written: list[str],
+        season_root: Path,
+        path: Path,
+        content: bytes,
+    ) -> None:
+        if self._write_bytes(path, content):
+            written.append(str(path.relative_to(season_root)))
+
+    def _write_bytes(self, path: Path, content: bytes) -> bool:
+        digest = hashlib.sha256(content).hexdigest()
+        with self._lock:
+            if self._digests.get(path) == digest:
+                return False
+            path.parent.mkdir(parents=True, exist_ok=True)
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+            )
+            temporary_path = Path(temporary_name)
+            try:
+                with os.fdopen(descriptor, "wb") as temporary_file:
+                    temporary_file.write(content)
+                    temporary_file.flush()
+                    os.fsync(temporary_file.fileno())
+                os.replace(temporary_path, path)
+            finally:
+                temporary_path.unlink(missing_ok=True)
+            self._digests[path] = digest
+        return True
+
+    def _season_name(self, bootstrap: Mapping[str, Any]) -> str:
+        if self.configured_season.casefold() != "auto":
+            return self.configured_season
+        deadlines = [
+            str(event.get("deadline_time"))
+            for event in bootstrap.get("events", [])
+            if event.get("deadline_time")
+        ]
+        if deadlines:
+            start_year = int(min(deadlines)[:4])
+            return f"{start_year}-{start_year + 1}"
+        raise ValueError(
+            "Cannot infer archive season from Official FPL; configure data_archive.season"
+        )
+
+    @staticmethod
+    def _json_bytes(payload: Any) -> bytes:
+        return (
+            json.dumps(
+                _json_safe(payload),
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            + "\n"
+        ).encode("utf-8")

--- a/src/official_fpl.py
+++ b/src/official_fpl.py
@@ -154,9 +154,13 @@ class OfficialFPLClient:
         """Return the official bonus-processing and league update state."""
         return self._mapping_resource("event-status/")
 
+    def event_live(self, gameweek: int) -> Mapping[str, Any]:
+        """Return the complete official live payload for one gameweek."""
+        return self._mapping_resource(f"event/{gameweek}/live/")
+
     def mapped_event_live(self, gameweek: int) -> Dict[str, Any]:
         """Map live official player scoring for a gameweek."""
-        payload = self._mapping_resource(f"event/{gameweek}/live/")
+        payload = self.event_live(gameweek)
         players = {player["id"]: player for player in self.mapped_players()}
         elements = []
         for element in payload.get("elements", []):
@@ -834,7 +838,15 @@ class OfficialFPLClient:
         history: Mapping[str, Any],
         teams: Mapping[int, str],
     ) -> Dict[str, Any]:
-        return OfficialFPLClient._common_player_values(player, teams) | {
+        # Keep every upstream field for future feature engineering. Canonical
+        # model fields remain unprefixed; the raw contract is namespaced so a
+        # future Official FPL field cannot silently overwrite one of them.
+        raw_official_values = {
+            f"official_{key}": value for key, value in history.items()
+        }
+        return raw_official_values | OfficialFPLClient._common_player_values(
+            player, teams
+        ) | {
             "gameweek": int(history["round"]),
             "was_home": bool(history.get("was_home")),
             "opponent_team_name": teams.get(int(history["opponent_team"])),

--- a/src/scout.py
+++ b/src/scout.py
@@ -19,6 +19,7 @@ from src.features import (
     normalize_fpl_columns,
     prepare_recent_player_features,
 )
+from src.data_archive import DataArchive
 from src.fpl_data_inference import FPLDataHistoryProvider
 from src.logger import get_logger
 from src.official_fpl import OfficialFPLClient
@@ -36,6 +37,20 @@ def _environment_bool(name: str) -> Optional[bool]:
     if normalized in {"0", "false", "no", "off"}:
         return False
     raise ValueError(f"{name} must be true or false")
+
+
+def _mounted_data_path(configured_path: Any) -> Any:
+    """Relocate configured data/* paths when the runtime mount differs."""
+    data_root = os.environ.get("OPENFPL_DATA_ROOT")
+    if not data_root or configured_path is None:
+        return configured_path
+    relative_path = Path(str(configured_path))
+    if relative_path.is_absolute():
+        return relative_path
+    parts = relative_path.parts
+    if parts and parts[0] == "data":
+        parts = parts[1:]
+    return Path(data_root).joinpath(*parts)
 
 
 class InferenceError(RuntimeError):
@@ -72,6 +87,7 @@ class FPLScout:
         model_loader: Callable[[str], Any] = joblib.load,
         official_client: Optional[OfficialFPLClient] = None,
         fpl_data_provider: Optional[FPLDataHistoryProvider] = None,
+        data_archive: Optional[DataArchive] = None,
     ) -> None:
         self.config = dict(config)
         official_config = self.config.get("official_fpl", {})
@@ -121,6 +137,7 @@ class FPLScout:
         if self.fpl_data_start_gameweek < 2:
             raise ValueError("fpl_data_inference.start_gameweek must be at least 2")
         self.fpl_data_provider = fpl_data_provider
+        self.data_archive = data_archive or DataArchive.from_config(self.config)
         self.last_data_enrichment: Dict[str, Any] = {
             "provider": "fpl-data",
             "status": "not-attempted",
@@ -128,8 +145,10 @@ class FPLScout:
         if self.fpl_data_enabled and self.fpl_data_provider is None:
             self.fpl_data_provider = FPLDataHistoryProvider(
                 season_value=self.fpl_data_season,
-                local_path=fpl_data_config.get("local_path"),
-                runtime_cache_path=fpl_data_config.get("runtime_cache_path"),
+                local_path=_mounted_data_path(fpl_data_config.get("local_path")),
+                runtime_cache_path=_mounted_data_path(
+                    fpl_data_config.get("runtime_cache_path")
+                ),
                 refresh_ttl_seconds=int(
                     fpl_data_config.get("refresh_ttl_seconds", 21600)
                 ),
@@ -550,8 +569,9 @@ class FPLScout:
         """Generate predictions from official history plus guarded enrichment."""
         resolved_gameweek = int(gameweek or self.official_client.next_gameweek())
         logger.info("Loading official FPL history for gameweek %d", resolved_gameweek)
-        history = self.official_client.player_history(resolved_gameweek)
-        logger.info("Loaded %d official FPL history rows", len(history))
+        official_history = self.official_client.player_history(resolved_gameweek)
+        history = official_history
+        logger.info("Loaded %d official FPL history rows", len(official_history))
 
         enrichment = {
             "provider": "fpl-data",
@@ -583,6 +603,25 @@ class FPLScout:
             if enrichment.get("status") == "applied"
             else "official-fpl"
         )
+        archive_result = self.data_archive.capture_inference(
+            official_client=self.official_client,
+            prediction_gameweek=resolved_gameweek,
+            official_history=official_history,
+            enriched_history=history,
+            predictions=result,
+            source=str(result.attrs["source"]),
+            enrichment=enrichment,
+            model_versions={
+                name: {
+                    key: value
+                    for key, value in metadata.items()
+                    if key in {"version", "last_trained", "year", "weight", "path"}
+                }
+                for name, metadata in self.config.get("models", {}).items()
+                if isinstance(metadata, Mapping)
+            },
+        )
+        result.attrs["archive"] = archive_result
         return result
 
     def select_optimal_team(self, predictions: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_data_archive.py
+++ b/tests/test_data_archive.py
@@ -1,0 +1,226 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+from src.data_archive import DataArchive
+
+
+class FakeOfficialClient:
+    def __init__(self):
+        self.live_calls = []
+        self.history_calls = []
+
+    def bootstrap(self):
+        return {
+            "events": [
+                {
+                    "id": 1,
+                    "deadline_time": "2026-08-15T10:00:00Z",
+                    "finished": True,
+                    "is_current": False,
+                },
+                {
+                    "id": 2,
+                    "deadline_time": "2026-08-22T10:00:00Z",
+                    "finished": False,
+                    "is_current": True,
+                },
+            ],
+            "elements": [{"id": 10, "web_name": "Player"}],
+            "teams": [{"id": 1, "name": "Arsenal"}],
+        }
+
+    def fixtures(self):
+        return [{"id": 100, "event": 2}]
+
+    def event_live(self, gameweek):
+        self.live_calls.append(gameweek)
+        return {
+            "elements": [
+                {"id": 10, "stats": {"minutes": 90, "total_points": gameweek}}
+            ]
+        }
+
+    def player_history(self, gameweek, selectable_only=True):
+        self.history_calls.append((gameweek, selectable_only))
+        return pd.DataFrame(
+            [
+                {
+                    "id": 10,
+                    "web_name": "Player",
+                    "gameweek": 1,
+                    "minutes": 90,
+                    "total_points": 6,
+                    "official_bps": 24,
+                }
+            ]
+        )
+
+
+def prediction_frame():
+    frame = pd.DataFrame(
+        [
+            {
+                "id": 10,
+                "web_name": "Player",
+                "gameweek": 2,
+                "expected_points": 5.5,
+            }
+        ]
+    )
+    frame.attrs["gameweek"] = 2
+    frame.attrs["source"] = "official-fpl+fpl-data"
+    frame.attrs["inference"] = {
+        "strategy": "model-ensemble",
+        "successful_models": ["ridge"],
+    }
+    return frame
+
+
+class DataArchiveTests(unittest.TestCase):
+    def test_data_root_environment_moves_archive_to_mounted_directory(self):
+        with patch.dict("os.environ", {"OPENFPL_DATA_ROOT": "/data"}, clear=False):
+            archive = DataArchive.from_config(
+                {"data_archive": {"enabled": True, "root_path": "data/archive"}}
+            )
+
+        self.assertEqual(archive.root_path, Path("/data/archive"))
+
+    def test_writes_season_gameweek_training_archive(self):
+        with tempfile.TemporaryDirectory() as directory:
+            archive = DataArchive(Path(directory), enabled=True)
+            client = FakeOfficialClient()
+            official = client.player_history(2)
+            enriched = official.assign(total_shots=3)
+            predictions = prediction_frame()
+
+            result = archive.capture_inference(
+                official_client=client,
+                prediction_gameweek=2,
+                official_history=official,
+                enriched_history=enriched,
+                predictions=predictions,
+                source="official-fpl+fpl-data",
+                enrichment={"provider": "fpl-data", "status": "applied"},
+                model_versions={"ridge": {"version": "v1"}},
+            )
+            squad_result = archive.capture_squad(predictions, predictions)
+
+            season = Path(directory) / "2026-2027"
+            expected = [
+                season / "official/snapshots/gw_02/bootstrap.json",
+                season / "official/snapshots/gw_02/fixtures.json",
+                season / "official/history/before_gw_02.csv",
+                season / "official/player-stats/gw_01.csv",
+                season / "official/live/gw_01.json",
+                season / "official/live/gw_02.json",
+                season / "enriched/history/before_gw_02.csv",
+                season / "enriched/player-stats/gw_01.csv",
+                season / "predictions/gw_02.csv",
+                season / "metadata/gw_02.json",
+                season / "squads/gw_02.json",
+            ]
+            self.assertEqual(result["status"], "saved")
+            self.assertEqual(squad_result["status"], "saved")
+            self.assertTrue(all(path.is_file() for path in expected))
+            self.assertIn(
+                "official_bps",
+                pd.read_csv(season / "official/player-stats/gw_01.csv").columns,
+            )
+            self.assertIn(
+                "total_shots",
+                pd.read_csv(season / "enriched/player-stats/gw_01.csv").columns,
+            )
+            metadata = json.loads(
+                (season / "metadata/gw_02.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(metadata["prediction_gameweek"], 2)
+            self.assertEqual(metadata["live_gameweeks"], [1, 2])
+            self.assertEqual(client.live_calls, [1, 2])
+
+    def test_does_not_refetch_finalized_live_gameweek(self):
+        with tempfile.TemporaryDirectory() as directory:
+            archive = DataArchive(Path(directory), enabled=True)
+            client = FakeOfficialClient()
+            history = client.player_history(2)
+            predictions = prediction_frame()
+            arguments = {
+                "official_client": client,
+                "prediction_gameweek": 2,
+                "official_history": history,
+                "enriched_history": history,
+                "predictions": predictions,
+                "source": "official-fpl",
+                "enrichment": {"status": "disabled"},
+                "model_versions": {},
+            }
+
+            archive.capture_inference(**arguments)
+            archive.capture_inference(**arguments)
+
+            self.assertEqual(client.live_calls, [1, 2, 2])
+
+    def test_archive_failure_does_not_escape(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root_file = Path(directory) / "not-a-directory"
+            root_file.write_text("occupied", encoding="utf-8")
+            archive = DataArchive(root_file, enabled=True)
+            history = FakeOfficialClient().player_history(2)
+
+            result = archive.capture_inference(
+                official_client=FakeOfficialClient(),
+                prediction_gameweek=2,
+                official_history=history,
+                enriched_history=history,
+                predictions=prediction_frame(),
+                source="official-fpl",
+                enrichment={"status": "disabled"},
+                model_versions={},
+            )
+
+            self.assertEqual(result["status"], "failed")
+            self.assertIn("Not a directory", result["error"])
+
+    def test_final_gameweek_uses_history_cutoff_39(self):
+        with tempfile.TemporaryDirectory() as directory:
+            archive = DataArchive(Path(directory), enabled=True)
+            client = FakeOfficialClient()
+            payload = client.bootstrap()
+            payload["events"] = [
+                {
+                    "id": gameweek,
+                    "deadline_time": f"2026-08-{min(gameweek, 28):02d}T10:00:00Z",
+                    "finished": True,
+                    "is_current": gameweek == 38,
+                }
+                for gameweek in range(1, 39)
+            ]
+            client.bootstrap = lambda: payload
+            history = client.player_history(38)
+
+            archive.capture_inference(
+                official_client=client,
+                prediction_gameweek=38,
+                official_history=history,
+                enriched_history=history,
+                predictions=prediction_frame(),
+                source="official-fpl",
+                enrichment={"status": "disabled"},
+                model_versions={},
+            )
+
+            self.assertIn((39, False), client.history_calls)
+            self.assertTrue(
+                (
+                    Path(directory)
+                    / "2026-2027/official/history/before_gw_39.csv"
+                ).is_file()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_official_fpl.py
+++ b/tests/test_official_fpl.py
@@ -138,6 +138,8 @@ class OfficialFPLClientTests(unittest.TestCase):
                     "recoveries": 5,
                     "tackles": 1,
                     "defensive_contribution": 3,
+                    "bonus": 2,
+                    "bps": 31,
                 }
             ],
             "fixtures": [],
@@ -158,6 +160,8 @@ class OfficialFPLClientTests(unittest.TestCase):
         self.assertEqual(result.loc[0, "goals"], 1.0)
         self.assertEqual(result.loc[0, "expected_goals"], 0.71)
         self.assertEqual(result.loc[0, "clean_sheet"], 1.0)
+        self.assertEqual(result.loc[0, "official_bonus"], 2)
+        self.assertEqual(result.loc[0, "official_bps"], 31)
 
     def test_retains_players_without_prior_match_history(self):
         payload = add_player(bootstrap(finished=True))

--- a/tests/test_scout.py
+++ b/tests/test_scout.py
@@ -1,11 +1,12 @@
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 
 from src.features import MODEL_FEATURES
-from src.scout import FPLScout, InferenceError
+from src.scout import FPLScout, InferenceError, _mounted_data_path
 
 
 class ConstantModel:
@@ -144,6 +145,12 @@ class ScoutInferenceTests(unittest.TestCase):
             }
 
         self.fixtures = fixtures
+
+    def test_data_root_environment_relocates_relative_data_paths(self):
+        with patch.dict("os.environ", {"OPENFPL_DATA_ROOT": "/data"}, clear=False):
+            result = _mounted_data_path("data/external/source.csv")
+
+        self.assertEqual(result, Path("/data/external/source.csv"))
 
     def test_weighted_ensemble_preserves_output_contract_and_caches_fixtures(self):
         models = {


### PR DESCRIPTION
## Summary

- archive raw Official FPL bootstrap, fixtures, and complete event-live payloads by season and gameweek
- persist all-player official history, enriched history, predictions, selected squads, and inference/model metadata
- retain every raw Official FPL history field with an `official_` prefix for future feature engineering
- store the enrichment source under the writable data mount and support `OPENFPL_DATA_ROOT=/data`
- handle the GW38 cutoff explicitly so the final gameweek is included
- expose archive status through `/api/health` and keep storage failures fail-open

## Archive layout

Artifacts are written below `data/archive/<season>/` with separate `official`, `enriched`, `predictions`, `squads`, and `metadata` paths. Completed live files are immutable; current snapshots are refreshed on subsequent inference requests.

## Deployment notes

- mount the data bucket read-write
- retain the model bucket as read-only
- set `OPENFPL_DATA_ROOT=/data` if the bucket is mounted at `/data` instead of `/app/data`
- trigger `/api/scout` after each finalized gameweek to guarantee collection during low traffic

## Verification

- `ruff check main.py src/data_archive.py src/official_fpl.py src/scout.py tests/test_data_archive.py tests/test_official_fpl.py tests/test_scout.py`
- `uv run python -m pytest -q tests/test_data_archive.py tests/test_official_fpl.py tests/test_scout.py tests/test_api_schema.py` (38 passed)
- `uv run python -m pytest -q --ignore=tests/test_features.py` (54 passed)
- Docker image build succeeded

The full unfiltered suite currently has a pre-existing collection error because `tests/test_features.py` imports `estimate_fixture_difficulty`, which is absent from the current `src/features.py`.